### PR TITLE
bugfix: set iframe's dimension to avoid some ui problem in ies

### DIFF
--- a/static/queen.css
+++ b/static/queen.css
@@ -30,8 +30,8 @@ h1 img {
   vertical-align: text-bottom;
 }
 iframe {
-  width: 0px;
-  height: 0px;
-  border: 10px solid #555555;
+  width: 20px;
+  height: 20px;
+  border: 4px solid #555555;
   margin: 20px;
 }


### PR DESCRIPTION
In ie7, if runner's iframe is 0*0, js cannot know if a dom element is visible, any element always be considered as unvisible, and in ie6789,  this would cause a element's position deviation.

I set it 20px*20px, this is a empirical value, if i set a value less than it, there  will be problem in ie9. 
